### PR TITLE
Set `forwrev` to 10 by default

### DIFF
--- a/flamel/flamel.py
+++ b/flamel/flamel.py
@@ -24,7 +24,7 @@ def main():
                              'time in both directions, with the specified '
                              'number of points in the time plot. The number '
                              'of time points (an integer) must be provided. '
-                             'Default: 0', default=0, type=int)
+                             'Default: 10', default=10, type=int)
     parser.add_argument('-g', '--breakdown', dest='breakdown',
                         help='Plot the free energy differences evaluated for '
                              'each pair of adjacent states for all methods, '


### PR DESCRIPTION
Fixes #18 

## Description
Sets the `forwrev` command line flags default to 10 (default of the underlying function) to stop flamel from breaking.

## Todos
  - [ ] Needs tests
